### PR TITLE
Adiciona controle do LED vermelho e arquivos do projeto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,62 @@
+# Generated Cmake Pico project file
+
+cmake_minimum_required(VERSION 3.13)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Initialise pico_sdk from installed location
+# (note this can come from environment, CMake cache etc)
+
+# == DO NOT EDIT THE FOLLOWING LINES for the Raspberry Pi Pico VS Code Extension to work ==
+if(WIN32)
+    set(USERHOME $ENV{USERPROFILE})
+else()
+    set(USERHOME $ENV{HOME})
+endif()
+set(sdkVersion 1.5.1)
+set(toolchainVersion 13_2_Rel1)
+set(picotoolVersion 2.0.0)
+set(picoVscode ${USERHOME}/.pico-sdk/cmake/pico-vscode.cmake)
+if (EXISTS ${picoVscode})
+    include(${picoVscode})
+endif()
+# ====================================================================================
+set(PICO_BOARD pico_w CACHE STRING "Board type")
+
+# Pull in Raspberry Pi Pico SDK (must be before project)
+include(pico_sdk_import.cmake)
+
+project(led_rgb_red C CXX ASM)
+
+# Initialise the Raspberry Pi Pico SDK
+pico_sdk_init()
+
+# Add executable. Default name is the project name, version 0.1
+
+add_executable(led_rgb_red led_rgb_red.c )
+
+pico_set_program_name(led_rgb_red "led_rgb_red")
+pico_set_program_version(led_rgb_red "0.1")
+
+# Modify the below lines to enable/disable output over UART/USB
+pico_enable_stdio_uart(led_rgb_red 0)
+pico_enable_stdio_usb(led_rgb_red 1)
+
+# Add the standard library to the build
+target_link_libraries(led_rgb_red
+        pico_stdlib)
+
+# Add the standard include files to the build
+target_include_directories(led_rgb_red PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}
+)
+
+# Add any user requested libraries
+target_link_libraries(led_rgb_red 
+        
+        )
+
+pico_add_extra_outputs(led_rgb_red)
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# Controle_Pinos

--- a/led_rgb_red.c
+++ b/led_rgb_red.c
@@ -1,0 +1,39 @@
+#include "pico/stdlib.h"
+#include "hardware/gpio.h"
+
+#define LED_VERMELHO_GPIO 13
+
+void inicializa_led_vermelho() {
+    gpio_init(LED_VERMELHO_GPIO);
+    gpio_set_dir(LED_VERMELHO_GPIO, GPIO_OUT);
+}
+
+int main() {
+    stdio_init_all();
+    inicializa_led_vermelho();
+
+    bool led_ligado = false; // Estado atual do LED
+
+    while (true) {
+        char tecla = '\0';
+
+        // Verifica se há uma tecla pressionada
+        if (scanf("%c", &tecla) == 1) {
+            if (tecla == 'A') { // Tecla associada ao LED vermelho
+                gpio_put(LED_VERMELHO_GPIO, 1); // Liga o LED
+                led_ligado = true;
+            }
+        }
+
+        // Se nenhuma tecla está sendo pressionada, desliga o LED
+        if (led_ligado && tecla != 'A') {
+            gpio_put(LED_VERMELHO_GPIO, 0); // Desliga o LED
+            led_ligado = false;
+        }
+
+        // Pequeno atraso para evitar leituras excessivas
+        sleep_ms(100);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
# Controle de LED Vermelho com Raspberry Pi Pico W

## Descrição
Este projeto utiliza o microcontrolador **Raspberry Pi Pico W** para controlar um **LED vermelho** conectado ao **GPIO 13**. A aplicação liga o LED quando a tecla **'A'** é pressionada e o desliga quando qualquer outra tecla for pressionada.

## Requisitos
- **Raspberry Pi Pico W**.
- **Pico SDK** configurado.
- **VS Code** (ou outro editor de sua preferência).
- **Simulador Wokwi** (opcional, se você preferir testar no simulador).

## Configuração
### 1. Clone o repositório:
   No terminal, execute o seguinte comando para clonar o repositório para sua máquina local:
   ```bash
   git clone https://github.com/Lucasferreira08/Controle_Pinos.git
